### PR TITLE
Convert Enumerable to array before call shift on it

### DIFF
--- a/newrelic_inode_agent
+++ b/newrelic_inode_agent
@@ -21,7 +21,7 @@ module INodeAgent
         start = start.gsub('Mounted on', 'Mounted_On')
         result = {}
         disks = start.lines
-        headers = disks.shift()
+        headers = disks.to_a.shift()
         headers = headers.split(/[ ]{1,}/)
         disks.each { |line|
             line = line.split(/[ ]{1,}/)


### PR DESCRIPTION
This PR aims to fix accessing `shift()` on an `Enumerable` instead of an array to avoid the following error:

```
[2015-10-20 08:11:50 UTC] ERROR: Error occurred in poll cycle: undefined method `shift' for #<Enumerator:0x000000029efd48>
```
